### PR TITLE
PM-10268: Add KEDA ScaledObject support

### DIFF
--- a/charts/kubernetes-service/Chart.yaml
+++ b/charts/kubernetes-service/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.2.0

--- a/charts/kubernetes-service/templates/datadog-metric.yml
+++ b/charts/kubernetes-service/templates/datadog-metric.yml
@@ -1,4 +1,4 @@
-{{- if and .Values.autoscaling.quartz (or .Values.autoscaling.quartz.targetQueueLength .Values.autoscaling.quartz.targetJobsPerPod) }}
+{{- if and .Values.autoscaling.quartz (or .Values.autoscaling.quartz.targetQueueLength .Values.autoscaling.quartz.targetJobsPerPod) (ne (default "hpa" .Values.autoscaling.type) "keda") }}
 apiVersion: datadoghq.com/v1alpha1
 kind: DatadogMetric
 metadata:
@@ -13,7 +13,7 @@ spec:
   {{- end }}
 {{- end }}
 {{- range $index, $queue := .Values.autoscaling.sqs }}
-{{- if and $queue.queueName $queue.targetQueueLength }}
+{{- if and $queue.queueName $queue.targetQueueLength (ne (default "hpa" $.Values.autoscaling.type) "keda") }}
 ---
 apiVersion: datadoghq.com/v1alpha1
 kind: DatadogMetric

--- a/charts/kubernetes-service/templates/hpa.yaml
+++ b/charts/kubernetes-service/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.autoscaling.enabled }}
+{{- if and .Values.autoscaling.enabled (ne (default "hpa" .Values.autoscaling.type) "keda") }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/kubernetes-service/templates/scaled-object.yaml
+++ b/charts/kubernetes-service/templates/scaled-object.yaml
@@ -37,11 +37,14 @@ spec:
         value: {{ .Values.autoscaling.targetMemoryUtilizationPercentage | quote }}
     {{- end }}
     {{- range $index, $queue := .Values.autoscaling.sqs }}
+    {{- if $queue.queueURL }}
     - type: aws-sqs-queue
       metadata:
         queueURL: {{ $queue.queueURL }}
         queueLength: {{ $queue.targetQueueLength | quote }}
         awsRegion: {{ default "us-east-2" $queue.awsRegion }}
+        # Defaults to "operator" for IRSA-based auth on keda-operator service account
         identityOwner: {{ default "operator" $queue.identityOwner }}
+    {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/kubernetes-service/templates/scaled-object.yaml
+++ b/charts/kubernetes-service/templates/scaled-object.yaml
@@ -1,0 +1,47 @@
+{{- if and .Values.autoscaling.enabled (eq (default "hpa" .Values.autoscaling.type) "keda") }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "kubernetes-service.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubernetes-service.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    {{- if or ( default .Values.rollout.blueGreen.enabled false ) ( default .Values.rollout.canary.enabled false ) }}
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
+    {{- end }}
+    name: {{ include "kubernetes-service.fullname" . }}
+  minReplicaCount: {{ .Values.autoscaling.minReplicas }}
+  maxReplicaCount: {{ .Values.autoscaling.maxReplicas }}
+  pollingInterval: {{ if and .Values.autoscaling.keda .Values.autoscaling.keda.pollingInterval }}{{ .Values.autoscaling.keda.pollingInterval }}{{ else }}30{{ end }}
+  cooldownPeriod: {{ if and .Values.autoscaling.keda .Values.autoscaling.keda.cooldownPeriod }}{{ .Values.autoscaling.keda.cooldownPeriod }}{{ else }}300{{ end }}
+  {{- with .Values.autoscaling.behavior }}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        {{- toYaml . | nindent 8 }}
+  {{- end }}
+  triggers:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: {{ .Values.autoscaling.targetCPUUtilizationPercentage | quote }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: memory
+      metricType: Utilization
+      metadata:
+        value: {{ .Values.autoscaling.targetMemoryUtilizationPercentage | quote }}
+    {{- end }}
+    {{- range $index, $queue := .Values.autoscaling.sqs }}
+    - type: aws-sqs-queue
+      metadata:
+        queueURL: {{ $queue.queueURL }}
+        queueLength: {{ $queue.targetQueueLength | quote }}
+        awsRegion: {{ default "us-east-2" $queue.awsRegion }}
+        identityOwner: {{ default "operator" $queue.identityOwner }}
+    {{- end }}
+{{- end }}

--- a/charts/kubernetes-service/values.yaml
+++ b/charts/kubernetes-service/values.yaml
@@ -76,23 +76,31 @@ resources:
 
 autoscaling:
   enabled: false
+  # type: "hpa" (default) uses HPA + DatadogMetric, "keda" uses KEDA ScaledObject
+  type: hpa
   minReplicas: 1
   maxReplicas: 1
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
-  # Quartz queue autoscaling
+  # Quartz queue autoscaling (HPA mode only - uses DatadogMetric)
   # quartz:
   #   targetQueueLength: 1  # Optional: Scale based on total queue length (type: Value)
   #   targetJobsPerPod: 1  # Optional: Scale based on jobs per pod (type: AverageValue)
   #   maxAge: 10m  # Optional: Max age for DatadogMetric data
   # SQS queue autoscaling - supports multiple queues
+  # HPA mode: uses DatadogMetric (requires queueName)
+  # KEDA mode: uses aws-sqs-queue trigger directly (requires queueURL)
   # sqs:
-  #   - queueName: "my-primary-queue"
-  #     targetQueueLength: 100  # Scale based on approximate_number_of_messages_visible
-  #     maxAge: 10m  # Optional: Max age for DatadogMetric data
-  #   - queueName: "my-secondary-queue"
-  #     targetQueueLength: 50
-  #     maxAge: 10m
+  #   - queueName: "my-primary-queue"       # HPA mode
+  #     queueURL: "https://sqs.us-east-2.amazonaws.com/123456789/my-primary-queue"  # KEDA mode
+  #     targetQueueLength: 100
+  #     awsRegion: us-east-2               # KEDA mode, default: us-east-2
+  #     identityOwner: operator            # KEDA mode, default: operator
+  #     maxAge: 10m                        # HPA mode only
+  # KEDA-specific settings
+  # keda:
+  #   pollingInterval: 30   # How often KEDA checks triggers (seconds)
+  #   cooldownPeriod: 300   # Cooldown before scaling back to minReplicas (seconds)
 #  behavior:
 #    scaleDown:
 #      policies:


### PR DESCRIPTION
## Summary
- Add `autoscaling.type` toggle (`hpa` default, `keda`) to kubernetes-service Helm chart
- New `templates/scaled-object.yaml` renders KEDA ScaledObject with `aws-sqs-queue` triggers
- HPA and DatadogMetric templates are skipped when `type: keda`
- Supports CPU/memory triggers, SQS queue triggers, custom behavior policies, and Argo Rollouts
- Backward compatible — existing services default to `type: hpa` with no changes needed

## Test plan
- [ ] Deploy athena-salesforce-extract-service in qa-3 with `autoscaling.type: keda` and verify ScaledObject is created
- [ ] Verify no HPA or DatadogMetric resources are created when type is keda
- [ ] Verify existing services with `type: hpa` (or unset) continue to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added KEDA autoscaling option alongside HPA, with configurable polling interval, cooldown, and mode-specific settings.
  * KEDA supports CPU, memory, and AWS SQS queue triggers; HPA mode continues to support Datadog-based metrics.
  * Autoscaling mode selection and per-mode configuration for queues and scaling behavior.

* **Chores**
  * Bumped chart version to 1.2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->