### PR TITLE
Pm 10268 keda postgresql quartz trigger

### DIFF
--- a/charts/kubernetes-service/Chart.yaml
+++ b/charts/kubernetes-service/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.2.1

--- a/charts/kubernetes-service/templates/scaled-object.yaml
+++ b/charts/kubernetes-service/templates/scaled-object.yaml
@@ -11,6 +11,9 @@ spec:
     {{- if or ( default .Values.rollout.blueGreen.enabled false ) ( default .Values.rollout.canary.enabled false ) }}
     apiVersion: argoproj.io/v1alpha1
     kind: Rollout
+    {{- else }}
+    apiVersion: apps/v1
+    kind: Deployment
     {{- end }}
     name: {{ include "kubernetes-service.fullname" . }}
   minReplicaCount: {{ .Values.autoscaling.minReplicas }}
@@ -47,7 +50,7 @@ spec:
         identityOwner: {{ default "operator" $queue.identityOwner }}
     {{- end }}
     {{- end }}
-    {{- if and .Values.autoscaling.postgresql .Values.autoscaling.postgresql.schema }}
+    {{- if and .Values.autoscaling.postgresql .Values.autoscaling.postgresql.schema .Values.autoscaling.postgresql.connection }}
     - type: postgresql
       metadata:
         query: {{ if .Values.autoscaling.postgresql.schedNamePrefix }}{{ printf "SELECT COUNT(*) FROM %s.qrtz_triggers WHERE trigger_state IN ('WAITING', 'ACQUIRED') AND sched_name = '%s-%s'" .Values.autoscaling.postgresql.schema .Values.autoscaling.postgresql.schedNamePrefix .Values.appVersion | quote }}{{ else }}{{ printf "SELECT COUNT(*) FROM %s.qrtz_triggers WHERE trigger_state IN ('WAITING', 'ACQUIRED')" .Values.autoscaling.postgresql.schema | quote }}{{ end }}

--- a/charts/kubernetes-service/templates/scaled-object.yaml
+++ b/charts/kubernetes-service/templates/scaled-object.yaml
@@ -26,6 +26,9 @@ spec:
       behavior:
         {{- toYaml . | nindent 8 }}
   {{- end }}
+  {{- if not (or .Values.autoscaling.targetCPUUtilizationPercentage .Values.autoscaling.targetMemoryUtilizationPercentage .Values.autoscaling.sqs (and .Values.autoscaling.postgresql .Values.autoscaling.postgresql.schema .Values.autoscaling.postgresql.connection.secretName .Values.autoscaling.postgresql.connection.secretKey)) }}
+  {{- fail "KEDA autoscaling requires at least one trigger (cpu, memory, sqs, or postgresql)" }}
+  {{- end }}
   triggers:
     {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: cpu
@@ -50,13 +53,16 @@ spec:
         identityOwner: {{ default "operator" $queue.identityOwner }}
     {{- end }}
     {{- end }}
-    {{- if and .Values.autoscaling.postgresql .Values.autoscaling.postgresql.schema .Values.autoscaling.postgresql.connection }}
+    {{- if and .Values.autoscaling.postgresql .Values.autoscaling.postgresql.schema .Values.autoscaling.postgresql.connection.secretName .Values.autoscaling.postgresql.connection.secretKey }}
     {{- $pg := .Values.autoscaling.postgresql }}
     {{- $query := printf "SELECT COUNT(*) FROM %s.qrtz_triggers WHERE trigger_state = 'WAITING' AND to_timestamp((next_fire_time + 5000) / 1000) <= CURRENT_TIMESTAMP" $pg.schema }}
     {{- if $pg.excludeGroups }}
     {{- $query = printf "%s AND trigger_group NOT IN ('%s')" $query (join "', '" $pg.excludeGroups) }}
     {{- end }}
     {{- if $pg.schedNamePrefix }}
+    {{- if not $.Values.appVersion }}
+    {{- fail "autoscaling.postgresql.schedNamePrefix requires appVersion to be set" }}
+    {{- end }}
     {{- $query = printf "%s AND sched_name = '%s-%s'" $query $pg.schedNamePrefix $.Values.appVersion }}
     {{- end }}
     - type: postgresql

--- a/charts/kubernetes-service/templates/scaled-object.yaml
+++ b/charts/kubernetes-service/templates/scaled-object.yaml
@@ -51,10 +51,18 @@ spec:
     {{- end }}
     {{- end }}
     {{- if and .Values.autoscaling.postgresql .Values.autoscaling.postgresql.schema .Values.autoscaling.postgresql.connection }}
+    {{- $pg := .Values.autoscaling.postgresql }}
+    {{- $query := printf "SELECT COUNT(*) FROM %s.qrtz_triggers WHERE trigger_state = 'WAITING' AND to_timestamp((next_fire_time + 5000) / 1000) <= CURRENT_TIMESTAMP" $pg.schema }}
+    {{- if $pg.excludeGroups }}
+    {{- $query = printf "%s AND trigger_group NOT IN ('%s')" $query (join "', '" $pg.excludeGroups) }}
+    {{- end }}
+    {{- if $pg.schedNamePrefix }}
+    {{- $query = printf "%s AND sched_name = '%s-%s'" $query $pg.schedNamePrefix $.Values.appVersion }}
+    {{- end }}
     - type: postgresql
       metadata:
-        query: {{ if .Values.autoscaling.postgresql.schedNamePrefix }}{{ printf "SELECT COUNT(*) FROM %s.qrtz_triggers WHERE trigger_state IN ('WAITING', 'ACQUIRED') AND sched_name = '%s-%s'" .Values.autoscaling.postgresql.schema .Values.autoscaling.postgresql.schedNamePrefix .Values.appVersion | quote }}{{ else }}{{ printf "SELECT COUNT(*) FROM %s.qrtz_triggers WHERE trigger_state IN ('WAITING', 'ACQUIRED')" .Values.autoscaling.postgresql.schema | quote }}{{ end }}
-        targetQueryValue: {{ .Values.autoscaling.postgresql.targetQueryValue | default "1" | quote }}
+        query: {{ $query | quote }}
+        targetQueryValue: {{ $pg.targetQueryValue | default "1" | quote }}
       authenticationRef:
         name: {{ printf "%s-postgresql-trigger-auth" (include "kubernetes-service.fullname" .) }}
     {{- end }}

--- a/charts/kubernetes-service/templates/scaled-object.yaml
+++ b/charts/kubernetes-service/templates/scaled-object.yaml
@@ -50,12 +50,7 @@ spec:
     {{- if and .Values.autoscaling.postgresql .Values.autoscaling.postgresql.schema }}
     - type: postgresql
       metadata:
-        userName: {{ .Values.autoscaling.postgresql.userName }}
-        host: {{ .Values.autoscaling.postgresql.host }}
-        port: {{ .Values.autoscaling.postgresql.port | default "5432" | quote }}
-        dbName: {{ .Values.autoscaling.postgresql.dbName }}
-        sslmode: {{ .Values.autoscaling.postgresql.sslmode | default "require" }}
-        query: {{ printf "SELECT COUNT(*) FROM %s.qrtz_triggers WHERE trigger_state IN ('WAITING', 'ACQUIRED')" .Values.autoscaling.postgresql.schema | quote }}
+        query: {{ if .Values.autoscaling.postgresql.schedNamePrefix }}{{ printf "SELECT COUNT(*) FROM %s.qrtz_triggers WHERE trigger_state IN ('WAITING', 'ACQUIRED') AND sched_name = '%s-%s'" .Values.autoscaling.postgresql.schema .Values.autoscaling.postgresql.schedNamePrefix .Values.appVersion | quote }}{{ else }}{{ printf "SELECT COUNT(*) FROM %s.qrtz_triggers WHERE trigger_state IN ('WAITING', 'ACQUIRED')" .Values.autoscaling.postgresql.schema | quote }}{{ end }}
         targetQueryValue: {{ .Values.autoscaling.postgresql.targetQueryValue | default "1" | quote }}
       authenticationRef:
         name: {{ printf "%s-postgresql-trigger-auth" (include "kubernetes-service.fullname" .) }}

--- a/charts/kubernetes-service/templates/scaled-object.yaml
+++ b/charts/kubernetes-service/templates/scaled-object.yaml
@@ -47,4 +47,17 @@ spec:
         identityOwner: {{ default "operator" $queue.identityOwner }}
     {{- end }}
     {{- end }}
+    {{- if and .Values.autoscaling.postgresql .Values.autoscaling.postgresql.schema }}
+    - type: postgresql
+      metadata:
+        userName: {{ .Values.autoscaling.postgresql.userName }}
+        host: {{ .Values.autoscaling.postgresql.host }}
+        port: {{ .Values.autoscaling.postgresql.port | default "5432" | quote }}
+        dbName: {{ .Values.autoscaling.postgresql.dbName }}
+        sslmode: {{ .Values.autoscaling.postgresql.sslmode | default "require" }}
+        query: {{ printf "SELECT COUNT(*) FROM %s.qrtz_triggers WHERE trigger_state IN ('WAITING', 'ACQUIRED')" .Values.autoscaling.postgresql.schema | quote }}
+        targetQueryValue: {{ .Values.autoscaling.postgresql.targetQueryValue | default "1" | quote }}
+      authenticationRef:
+        name: {{ printf "%s-postgresql-trigger-auth" (include "kubernetes-service.fullname" .) }}
+    {{- end }}
 {{- end }}

--- a/charts/kubernetes-service/templates/scaled-object.yaml
+++ b/charts/kubernetes-service/templates/scaled-object.yaml
@@ -26,7 +26,7 @@ spec:
       behavior:
         {{- toYaml . | nindent 8 }}
   {{- end }}
-  {{- if not (or .Values.autoscaling.targetCPUUtilizationPercentage .Values.autoscaling.targetMemoryUtilizationPercentage .Values.autoscaling.sqs (and .Values.autoscaling.postgresql .Values.autoscaling.postgresql.schema .Values.autoscaling.postgresql.connection.secretName .Values.autoscaling.postgresql.connection.secretKey)) }}
+  {{- if not (or .Values.autoscaling.targetCPUUtilizationPercentage .Values.autoscaling.targetMemoryUtilizationPercentage .Values.autoscaling.sqs (and .Values.autoscaling.postgresql .Values.autoscaling.postgresql.schema .Values.autoscaling.postgresql.connection .Values.autoscaling.postgresql.connection.secretName .Values.autoscaling.postgresql.connection.secretKey)) }}
   {{- fail "KEDA autoscaling requires at least one trigger (cpu, memory, sqs, or postgresql)" }}
   {{- end }}
   triggers:
@@ -53,7 +53,7 @@ spec:
         identityOwner: {{ default "operator" $queue.identityOwner }}
     {{- end }}
     {{- end }}
-    {{- if and .Values.autoscaling.postgresql .Values.autoscaling.postgresql.schema .Values.autoscaling.postgresql.connection.secretName .Values.autoscaling.postgresql.connection.secretKey }}
+    {{- if and .Values.autoscaling.postgresql .Values.autoscaling.postgresql.schema .Values.autoscaling.postgresql.connection .Values.autoscaling.postgresql.connection.secretName .Values.autoscaling.postgresql.connection.secretKey }}
     {{- $pg := .Values.autoscaling.postgresql }}
     {{- $query := printf "SELECT COUNT(*) FROM %s.qrtz_triggers WHERE trigger_state = 'WAITING' AND to_timestamp((next_fire_time + 5000) / 1000) <= CURRENT_TIMESTAMP" $pg.schema }}
     {{- if $pg.excludeGroups }}

--- a/charts/kubernetes-service/templates/trigger-authentication.yaml
+++ b/charts/kubernetes-service/templates/trigger-authentication.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.autoscaling.enabled (eq (default "hpa" .Values.autoscaling.type) "keda") }}
-{{- if and .Values.autoscaling.postgresql .Values.autoscaling.postgresql.schema .Values.autoscaling.postgresql.connection.secretName .Values.autoscaling.postgresql.connection.secretKey }}
+{{- if and .Values.autoscaling.postgresql .Values.autoscaling.postgresql.schema .Values.autoscaling.postgresql.connection .Values.autoscaling.postgresql.connection.secretName .Values.autoscaling.postgresql.connection.secretKey }}
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/charts/kubernetes-service/templates/trigger-authentication.yaml
+++ b/charts/kubernetes-service/templates/trigger-authentication.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.autoscaling.enabled (eq (default "hpa" .Values.autoscaling.type) "keda") }}
+{{- if and .Values.autoscaling.postgresql .Values.autoscaling.postgresql.password }}
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: {{ printf "%s-postgresql-trigger-auth" (include "kubernetes-service.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubernetes-service.labels" . | nindent 4 }}
+spec:
+  secretTargetRef:
+    - parameter: password
+      name: {{ .Values.autoscaling.postgresql.password.secretName }}
+      key: {{ .Values.autoscaling.postgresql.password.secretKey }}
+{{- end }}
+{{- end }}

--- a/charts/kubernetes-service/templates/trigger-authentication.yaml
+++ b/charts/kubernetes-service/templates/trigger-authentication.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.autoscaling.enabled (eq (default "hpa" .Values.autoscaling.type) "keda") }}
-{{- if and .Values.autoscaling.postgresql .Values.autoscaling.postgresql.connection }}
+{{- if and .Values.autoscaling.postgresql .Values.autoscaling.postgresql.schema .Values.autoscaling.postgresql.connection }}
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/charts/kubernetes-service/templates/trigger-authentication.yaml
+++ b/charts/kubernetes-service/templates/trigger-authentication.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.autoscaling.enabled (eq (default "hpa" .Values.autoscaling.type) "keda") }}
-{{- if and .Values.autoscaling.postgresql .Values.autoscaling.postgresql.password }}
+{{- if and .Values.autoscaling.postgresql .Values.autoscaling.postgresql.connection }}
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:
@@ -9,8 +9,8 @@ metadata:
     {{- include "kubernetes-service.labels" . | nindent 4 }}
 spec:
   secretTargetRef:
-    - parameter: password
-      name: {{ .Values.autoscaling.postgresql.password.secretName }}
-      key: {{ .Values.autoscaling.postgresql.password.secretKey }}
+    - parameter: connection
+      name: {{ .Values.autoscaling.postgresql.connection.secretName }}
+      key: {{ .Values.autoscaling.postgresql.connection.secretKey }}
 {{- end }}
 {{- end }}

--- a/charts/kubernetes-service/templates/trigger-authentication.yaml
+++ b/charts/kubernetes-service/templates/trigger-authentication.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.autoscaling.enabled (eq (default "hpa" .Values.autoscaling.type) "keda") }}
-{{- if and .Values.autoscaling.postgresql .Values.autoscaling.postgresql.schema .Values.autoscaling.postgresql.connection }}
+{{- if and .Values.autoscaling.postgresql .Values.autoscaling.postgresql.schema .Values.autoscaling.postgresql.connection.secretName .Values.autoscaling.postgresql.connection.secretKey }}
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/charts/kubernetes-service/values.yaml
+++ b/charts/kubernetes-service/values.yaml
@@ -99,18 +99,14 @@ autoscaling:
   #     maxAge: 10m                        # HPA mode only
   # Quartz queue autoscaling via direct PostgreSQL query (KEDA mode only)
   # Scales based on pending/acquired jobs in the qrtz_triggers table.
-  # Requires a TriggerAuthentication referencing the DB password secret.
+  # Requires a TriggerAuthentication referencing a libpq connection string in a secret.
   # postgresql:
   #   schema: "my_service_dev_1"          # PostgreSQL schema containing qrtz_triggers
-  #   userName: "prodlyuser"              # DB username (inline, not from secret)
-  #   host: "db-host.us-east-2.rds.amazonaws.com"
-  #   port: "5432"                        # Optional, default: 5432
-  #   dbName: "my_database"              # PostgreSQL database name
-  #   sslmode: "require"                 # Optional, default: require
-  #   targetQueryValue: "1"             # Optional, default: 1 (jobs per pod)
-  #   password:
+  #   schedNamePrefix: "my-service-scheduler"  # Optional: filters by sched_name = "{prefix}-{appVersion}"
+  #   targetQueryValue: "1"              # Optional, default: 1 (jobs per pod)
+  #   connection:
   #     secretName: "dev-1-my-service-secret"
-  #     secretKey: "my_service.rds.password"
+  #     secretKey: "keda.postgresql.connection"
   # KEDA-specific settings
   # keda:
   #   pollingInterval: 30   # How often KEDA checks triggers (seconds)

--- a/charts/kubernetes-service/values.yaml
+++ b/charts/kubernetes-service/values.yaml
@@ -97,6 +97,20 @@ autoscaling:
   #     awsRegion: us-east-2               # KEDA mode, default: us-east-2
   #     identityOwner: operator            # KEDA mode, default: operator
   #     maxAge: 10m                        # HPA mode only
+  # Quartz queue autoscaling via direct PostgreSQL query (KEDA mode only)
+  # Scales based on pending/acquired jobs in the qrtz_triggers table.
+  # Requires a TriggerAuthentication referencing the DB password secret.
+  # postgresql:
+  #   schema: "my_service_dev_1"          # PostgreSQL schema containing qrtz_triggers
+  #   userName: "prodlyuser"              # DB username (inline, not from secret)
+  #   host: "db-host.us-east-2.rds.amazonaws.com"
+  #   port: "5432"                        # Optional, default: 5432
+  #   dbName: "my_database"              # PostgreSQL database name
+  #   sslmode: "require"                 # Optional, default: require
+  #   targetQueryValue: "1"             # Optional, default: 1 (jobs per pod)
+  #   password:
+  #     secretName: "dev-1-my-service-secret"
+  #     secretKey: "my_service.rds.password"
   # KEDA-specific settings
   # keda:
   #   pollingInterval: 30   # How often KEDA checks triggers (seconds)


### PR DESCRIPTION
## Description

> Optional description here

## Checklists

### Change type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] Artifact version was updated in respective `Chart.yaml` according to the rules defined in [Semantic Versioning](https://semver.org/) rules
- [ ] Security design review passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PostgreSQL-based autoscaling via Quartz job-queue metrics (KEDA mode) and conditional TriggerAuthentication support
  * Retains support for Argo Rollouts (blue/green, canary) alongside standard Kubernetes deployments
  * Added pre-configuration guard that surfaces a clear error when no autoscaling trigger is provided

* **Documentation**
  * Added configuration guidance for PostgreSQL autoscaling: schema, scheduler prefix, query target, and secret-based connection

* **Chores**
  * Chart version bumped to 1.2.1
<!-- end of auto-generated comment: release notes by coderabbit.ai -->