### PR TITLE
PM-10268: add Helm ownership annotations to KEDA resources

### DIFF
--- a/charts/kubernetes-service/Chart.yaml
+++ b/charts/kubernetes-service/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.1
+version: 1.2.2

--- a/charts/kubernetes-service/templates/scaled-object.yaml
+++ b/charts/kubernetes-service/templates/scaled-object.yaml
@@ -4,6 +4,9 @@ kind: ScaledObject
 metadata:
   name: {{ include "kubernetes-service.fullname" . }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "meta.helm.sh/release-name": {{ .Release.Name }}
+    "meta.helm.sh/release-namespace": {{ .Release.Namespace }}
   labels:
     {{- include "kubernetes-service.labels" . | nindent 4 }}
 spec:

--- a/charts/kubernetes-service/templates/trigger-authentication.yaml
+++ b/charts/kubernetes-service/templates/trigger-authentication.yaml
@@ -5,6 +5,9 @@ kind: TriggerAuthentication
 metadata:
   name: {{ printf "%s-postgresql-trigger-auth" (include "kubernetes-service.fullname" .) }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "meta.helm.sh/release-name": {{ .Release.Name }}
+    "meta.helm.sh/release-namespace": {{ .Release.Namespace }}
   labels:
     {{- include "kubernetes-service.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
## Summary
- Add `meta.helm.sh/release-name` and `meta.helm.sh/release-namespace` annotations to ScaledObject and TriggerAuthentication templates
- Prevents "invalid ownership metadata" errors when deploying with skaffold after ArgoCD has created the resources
- Bump chart version to 1.2.2

## Test plan
- [ ] Verify `helm template` renders annotations correctly
- [ ] Deploy with ArgoCD, then verify `skaffold deploy` works without ownership errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated chart version to 1.2.2
  * Added Helm release metadata for improved deployment tracking and management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->